### PR TITLE
[RFC] Custom pre- and post processing in convert_doc

### DIFF
--- a/src/readers.jl
+++ b/src/readers.jl
@@ -51,10 +51,14 @@ end
 
 
 """Read and parse input document"""
-function read_doc(source::AbstractString, format=:auto)
+function read_doc(source::AbstractString, format=:auto; preprocess = identity)
     format == :auto && (format = detect_informat(source))
     document = readstring(source)
     document = replace(document, "\r\n", "\n")
+
+    # let user do some custom pre-processing
+    document = preprocess(document)
+
     parsed = parse_doc(document, format)
     header = parse_header(parsed[1])
     doc = WeaveDoc(source, parsed, header)

--- a/src/writers.jl
+++ b/src/writers.jl
@@ -30,7 +30,7 @@ function detect_outformat(outfile::String)
 end
 
 """
-`convert_doc(infile::AbstractString, outfile::AbstractString; format = nothing)`
+`convert_doc(infile::AbstractString, outfile::AbstractString; format = nothing, preprocess = identity, postprocess = identity)`
 
 Convert Weave documents between different formats
 
@@ -38,15 +38,23 @@ Convert Weave documents between different formats
 * `outfile` = Name of the output document
 * `format` = Output format (optional). Detected from outfile extension, but can
   be set to `"script"`, `"markdown"`, `"notebook"` or `"noweb"`.
+* `preprocess`,`postprocess`: custom pre- and post processing functions.
+  The functions should accept a string and return a processed string.
+  `preprocess` is called on the raw string read from `infile` and `postprocess`
+  called on the string just before writing to file.
 """
-function convert_doc(infile::AbstractString, outfile::AbstractString; format = nothing)
-  doc = read_doc(infile)
+function convert_doc(infile::AbstractString, outfile::AbstractString; format = nothing,
+                     preprocess = identity, postprocess = identity)
+  doc = read_doc(infile, preprocess = preprocess)
 
   if format == nothing
     format = detect_outformat(outfile)
   end
 
   converted = convert_doc(doc, output_formats[format])
+
+  # let user do some custom post-processing
+  converted = postprocess(converted)
 
   open(outfile, "w") do f
     write(f, converted)


### PR DESCRIPTION
This lets the user supply a `preprocess` and a `postprocess` function to `convert_doc`.
Example use cases:
 - Remove inline references (``[`function`](@ref)``) when converting to a notebook
 - Change codeblocks (```` ```julia ````) to Documenter doctests (```` ```jldoctest ````) or Documenter examples (```` ```@example $name ````)
 - Custom filtering of lines see e.g. https://github.com/Evizero/Augmentor.jl/blob/master/docs/exampleweaver.jl

and more.