### PR TITLE
Fix hooks and add a push/pop hook to the test

### DIFF
--- a/src/Weave.jl
+++ b/src/Weave.jl
@@ -226,11 +226,11 @@ include_weave(source, informat=:auto) = include_weave(Main, source, informat)
 #but note that Weave hooks take the chunk as input
 const preexecute_hooks = Function[]
 push_preexecute_hook(f::Function) = push!(preexecute_hooks, f)
-pop_preexecute_hook(f::Function) = splice!(preexecute_hooks, findfirst(preexecute_hooks, f))
+pop_preexecute_hook(f::Function) = splice!(preexecute_hooks, findfirst(x -> x == f, preexecute_hooks))
 
 const postexecute_hooks = Function[]
 push_postexecute_hook(f::Function) = push!(postexecute_hooks, f)
-pop_postexecute_hook(f::Function) = splice!(postexecute_hooks, findfirst(postexecute_hooks, f))
+pop_postexecute_hook(f::Function) = splice!(postexecute_hooks, findfirst(x -> x == f, postexecute_hooks))
 
 include("chunks.jl")
 include("config.jl")

--- a/test/chunk_options.jl
+++ b/test/chunk_options.jl
@@ -5,7 +5,9 @@ cleanup = true
 
 VER = "$(VERSION.major).$(VERSION.minor)"
 
+Weave.push_preexecute_hook(identity)
 weave("documents/chunk_options.noweb")
+Weave.pop_preexecute_hook(identity)
 result =  read("documents/chunk_options.md", String)
 ref =  read("documents/chunk_options_ref.md", String)
 @test result == ref


### PR DESCRIPTION
These hooks are currently broken due to a Base change in `findfirst`. Hopefully, this fixes those.

I also included a push/pop hook in a test.

 