### PR TITLE
Add html rendering of Markdown tables

### DIFF
--- a/src/WeaveMarkdown/html.jl
+++ b/src/WeaveMarkdown/html.jl
@@ -1,6 +1,6 @@
 #module Markdown2HTML
 # Markdown to HTML writer, Modified from Julia Base.Markdown html writer
-using Markdown: MD, Header, Code, Paragraph, BlockQuote, Footnote,
+using Markdown: MD, Header, Code, Paragraph, BlockQuote, Footnote, Table,
       Admonition, List, HorizontalRule, Bold, Italic, Image, Link, LineBreak,
       LaTeX, isordered
 
@@ -165,6 +165,20 @@ end
 
 function html(io::IO, comment::Comment)
     write(io, "\n<!-- $(comment.text) -->\n")
+end
+
+function html(io::IO, md::Table)
+    withtag(io, :table) do
+        for (i, row) in enumerate(md.rows)
+            withtag(io, :tr) do
+                for c in md.rows[i]
+                    withtag(io, i == 1 ? :th : :td) do
+                        htmlinline(io, c)
+                    end
+                end
+            end
+        end
+    end
 end
 
 html(io::IO, x) = tohtml(io, x)

--- a/test/markdown_test.jl
+++ b/test/markdown_test.jl
@@ -39,6 +39,10 @@ x = 3
 
 > Some important quote
 
+head 1 | head 2
+-------|--------
+`code` | no code
+
 """, flavor = WeaveMarkdown.weavemd))
 
 ref_html = """<h1>H1</h1>
@@ -70,6 +74,7 @@ more math
 <blockquote>
 <p>Some important quote</p>
 </blockquote>
+<table><tr><th>head 1</th><th>head 2</th></tr><tr><td><code>code</code></td><td>no code</td></tr></table>
 """
 
 @test html == ref_html


### PR DESCRIPTION
I think this was just overlooked. The `Table` method is from Markdown/src/GitHub/table.jl while all the others are from Markdown/src/render/html.jl

Closes #220.