### PR TITLE
fix docs badges in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ weave(joinpath(dirname(pathof(Weave)), "../examples", "FIR_design.jmd"),
 
 Documenter.jl with MKDocs generated documentation:
 
-[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://mpastell.github.io/Weave.jl/stable)
-[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://mpastell.github.io/Weave.jl/latest)
+[![](https://img.shields.io/badge/docs-stable-blue.svg)](http://weavejl.mpastell.com/stable/)
+[![](https://img.shields.io/badge/docs-dev-blue.svg)](http://weavejl.mpastell.com/dev/)
 
 ## Editor support
 


### PR DESCRIPTION
The badges in the docs subsection point to the old-style Documenter.jl URLs,
instead of the correct ones (which are used for the badges at the top) so I just
copied those.