### PR TITLE
Fix displayed output produced by capture_output

### DIFF
--- a/src/run.jl
+++ b/src/run.jl
@@ -228,14 +228,12 @@ function capture_output(expr, SandBox::Module, term, disp,
     reader = @async read(rw, String)
     try
         obj = Core.eval(SandBox, expr)
-        if (term || disp) && typeof(expr) == Expr && expr.head != :toplevel
+        if (term || disp) && (typeof(expr) != Expr || expr.head != :toplevel)
             obj != nothing && display(obj)
-        elseif typeof(expr) == Symbol
-            display(obj)
         #This shows images and lone variables, result can
         #Handle last line sepately
         elseif lastline && obj != nothing
-            (expr.head != :toplevel) && display(obj)
+            (typeof(expr) != Expr || expr.head != :toplevel) && display(obj)
         end
     catch E
         throw_errors && throw(E)


### PR DESCRIPTION
`capture_output` did some strange things on master (See screenshots). Basically everything that's not an `Expr` (`:("string")`, `:(1)`, ...) did not produce any output in term mode. A Symbol always produced an output no matter which mode and if the last line was not an `Expr` it failed because of the missing field `head`.

**Script mode:**
![image](https://user-images.githubusercontent.com/13043943/63434460-70fd6700-c425-11e9-8b6b-1525b392ee4b.png)
![image](https://user-images.githubusercontent.com/13043943/63434468-73f85780-c425-11e9-8aa0-cf5ea2bb8898.png)

**Term mode:**
![image](https://user-images.githubusercontent.com/13043943/63434466-72c72a80-c425-11e9-8657-2bb2e1fb2dbd.png)
![image](https://user-images.githubusercontent.com/13043943/63434472-75c21b00-c425-11e9-9d51-8bc6e59f745a.png)
