### PR TITLE
Improve usage of different figure environments in latex

### DIFF
--- a/doc/src/chunk_options.md
+++ b/doc/src/chunk_options.md
@@ -25,13 +25,13 @@ Weave currently supports the following chunk options with the following defaults
 
 * `fig_width`. Figure width passed to plotting library e.g. `800`
 * `fig_height` Figure height passed to plotting library
-* `out_width`. Width of saved figure in output markup e.g. "50%", "12cm", `\\0.5linewidth`
+* `out_width`. Width of saved figure in output markup e.g. "50%", "12cm", `0.5\linewidth`
 * `out_height`. Height of saved figure in output markup
 * `dpi`=96. Resolution of saved figures.
 * `fig_cap`. Figure caption.
 * `label`. Chunk label, will be used for figure labels in Latex as fig:label
 * `fig_ext`. File extension (format) of saved figures.
-* `fig_pos="htpb"`. Figure position in Latex.  
+* `fig_pos="!h"`. Figure position in Latex.
 * `fig_env="figure"`. Figure environment in Latex.
 
 

--- a/src/formatters.jl
+++ b/src/formatters.jl
@@ -243,6 +243,16 @@ const adoc = AsciiDoc("AsciiDoc",
         :doctype => "asciidoc"
 ))
 
+function md_length_to_latex(def,reference)
+    if occursin("%",def)
+        _def = tryparse(Float64,replace(def,"%"=>""))
+        _def == nothing && return def
+        perc = round(_def/100,digits=2)
+        return "$perc$reference"
+    end
+    return def
+end
+
 function formatfigures(chunk, docformat::Union{Tex,JMarkdown2tex})
   fignames = chunk.figures
   caption = chunk.options[:fig_cap]
@@ -260,9 +270,9 @@ function formatfigures(chunk, docformat::Union{Tex,JMarkdown2tex})
   (f_pos == nothing) && (f_pos = "!h")
   #Set size
   attribs = ""
-  width == nothing || (attribs = "width=$width")
+  width == nothing || (attribs = "width=$(md_length_to_latex(width,"\\linewidth"))")
   (attribs != "" && height != nothing ) && (attribs *= ",")
-  height == nothing    || (attribs *= "height=$height")
+  height == nothing    || (attribs *= "height=$(md_length_to_latex(height,"\\paperheight"))")
 
     if f_env != nothing
       result *= "\\begin{$f_env}"

--- a/src/formatters.jl
+++ b/src/formatters.jl
@@ -243,69 +243,7 @@ const adoc = AsciiDoc("AsciiDoc",
         :doctype => "asciidoc"
 ))
 
-
-function formatfigures(chunk, docformat::Tex)
-    fignames = chunk.figures
-    caption = chunk.options[:fig_cap]
-    width = chunk.options[:out_width]
-    height = chunk.options[:out_height]
-    f_pos = chunk.options[:fig_pos]
-    f_env = chunk.options[:fig_env]
-
-    if f_env == nothing && caption != nothing
-      f_env = "figure"
-    end
-
-    f_pos == nothing && (f_pos = "!h")
-
-    result = ""
-    figstring = ""
-
-    #Set size
-    attribs = ""
-    width == nothing || (attribs = "width=$width")
-    (attribs != "" && height != nothing ) && (attribs *= ",")
-    height == nothing    || (attribs *= "height=$height")
-
-
-    if f_env != nothing
-        result *= """\\begin{$f_env}[$f_pos]\n"""
-    end
-
-
-    for fig = fignames
-
-
-        if splitext(fig)[2] == ".tex" #Tikz figures
-            figstring *= "\\resizebox{$width}{!}{\\input{$fig}}\n"
-        else
-            figstring *= "\\includegraphics[$attribs]{$fig}\n"
-        end
-    end
-
-    # Figure environment
-    if caption != nothing
-        result *= string("\\center\n",
-                         "$figstring",
-                         "\\caption{$caption}\n")
-    else
-        result *= figstring
-    end
-
-    if chunk.options[:label] != nothing && f_env !=nothing
-        label = chunk.options[:label]
-        result *= "\\label{fig:$label}\n"
-    end
-
-
-    if f_env != nothing
-        result *= "\\end{$f_env}\n"
-    end
-
-   return result
-end
-
-function formatfigures(chunk, docformat::JMarkdown2tex)
+function formatfigures(chunk, docformat::Union{Tex,JMarkdown2tex})
   fignames = chunk.figures
   caption = chunk.options[:fig_cap]
   width = chunk.options[:out_width]

--- a/src/formatters.jl
+++ b/src/formatters.jl
@@ -257,23 +257,20 @@ function formatfigures(chunk, docformat::Union{Tex,JMarkdown2tex})
     f_env = "figure"
   end
 
-  f_pos == nothing && (f_pos = "!h")
-
+  (f_pos == nothing) && (f_pos = "!h")
   #Set size
   attribs = ""
   width == nothing || (attribs = "width=$width")
   (attribs != "" && height != nothing ) && (attribs *= ",")
   height == nothing    || (attribs *= "height=$height")
 
-
-  if f_env != nothing
-      result *= """\\begin{$f_env}[$f_pos]\n"""
+    if f_env != nothing
+      result *= "\\begin{$f_env}"
+      (f_pos != "") && (result *= "[$f_pos]")
+      result *= "\n"
   end
 
-
   for fig = fignames
-
-
       if splitext(fig)[2] == ".tex" #Tikz figures
           figstring *= "\\resizebox{$width}{!}{\\input{$fig}}\n"
       else

--- a/test/figureformatter_test.jl
+++ b/test/figureformatter_test.jl
@@ -7,7 +7,6 @@ options = merge(Weave.rcParams[:chunk_defaults], chunk.options)
 merge!(chunk.options, options)
 chunk.figures = ["figs/figures_plot1.png"]
 
-
 @test Weave.formatfigures(chunk, Weave.md2tex) == "\\includegraphics{figs/figures_plot1.png}\n"
 @test Weave.formatfigures(chunk, Weave.tex) == "\\includegraphics{figs/figures_plot1.png}\n"
 @test Weave.formatfigures(chunk, Weave.texminted) == "\\includegraphics{figs/figures_plot1.png}\n"
@@ -34,3 +33,9 @@ chunk.options[:label] = "somefig"
 @test Weave.formatfigures(chunk, Weave.pandoc) == "![Nice plot](figs/figures_plot1.png){width=100% #fig:somefig}\n"
 @test Weave.formatfigures(chunk, Weave.tex) == "\\begin{figure}[!h]\n\\center\n\\includegraphics[width=100%]{figs/figures_plot1.png}\n\\caption{Nice plot}\n\\label{fig:somefig}\n\\end{figure}\n"
 @test Weave.formatfigures(chunk, Weave.tex) == Weave.formatfigures(chunk, Weave.md2tex)
+
+chunk.options[:label] = nothing
+chunk.options[:fig_cap] = nothing
+chunk.options[:fig_env] = "center"
+chunk.options[:fig_pos] = ""
+@test Weave.formatfigures(chunk, Weave.tex) == "\\begin{center}\n\\includegraphics[width=100%]{figs/figures_plot1.png}\n\\end{center}\n"

--- a/test/figureformatter_test.jl
+++ b/test/figureformatter_test.jl
@@ -9,8 +9,8 @@ chunk.figures = ["figs/figures_plot1.png"]
 
 
 @test Weave.formatfigures(chunk, Weave.md2tex) == "\\includegraphics{figs/figures_plot1.png}\n"
-@test Weave.formatfigures(chunk, Weave.tex) == "\\includegraphics[]{figs/figures_plot1.png}\n"
-@test Weave.formatfigures(chunk, Weave.texminted) == "\\includegraphics[]{figs/figures_plot1.png}\n"
+@test Weave.formatfigures(chunk, Weave.tex) == "\\includegraphics{figs/figures_plot1.png}\n"
+@test Weave.formatfigures(chunk, Weave.texminted) == "\\includegraphics{figs/figures_plot1.png}\n"
 @test Weave.formatfigures(chunk, Weave.pandoc) == "![](figs/figures_plot1.png)\\ \n\n"
 @test Weave.formatfigures(chunk, Weave.github) == "![](figs/figures_plot1.png)\n"
 @test Weave.formatfigures(chunk, Weave.hugo) == "{{< figure src=\"../figs/figures_plot1.png\"  >}}"

--- a/test/figureformatter_test.jl
+++ b/test/figureformatter_test.jl
@@ -21,9 +21,9 @@ chunk.options[:out_width] = "100%"
 @test Weave.formatfigures(chunk, Weave.rst) == ".. image:: figs/figures_plot1.png\n   :width: 100%\n\n"
 
 chunk.options[:fig_cap] = "Nice plot"
-@test Weave.formatfigures(chunk, Weave.tex) == "\\begin{figure}[!h]\n\\center\n\\includegraphics[width=100%]{figs/figures_plot1.png}\n\\caption{Nice plot}\n\\end{figure}\n"
+@test Weave.formatfigures(chunk, Weave.tex) == "\\begin{figure}[!h]\n\\center\n\\includegraphics[width=1.0\\linewidth]{figs/figures_plot1.png}\n\\caption{Nice plot}\n\\end{figure}\n"
 @test Weave.formatfigures(chunk, Weave.pandoc) == "![Nice plot](figs/figures_plot1.png){width=100%}\n"
-@test Weave.formatfigures(chunk, Weave.md2tex) == "\\begin{figure}[!h]\n\\center\n\\includegraphics[width=100%]{figs/figures_plot1.png}\n\\caption{Nice plot}\n\\end{figure}\n"
+@test Weave.formatfigures(chunk, Weave.md2tex) == "\\begin{figure}[!h]\n\\center\n\\includegraphics[width=1.0\\linewidth]{figs/figures_plot1.png}\n\\caption{Nice plot}\n\\end{figure}\n"
 @test Weave.formatfigures(chunk, Weave.md2html) == "<figure>\n<img src=\"figs/figures_plot1.png\" width=\"100%\" />\n<figcaption>Nice plot</figcaption>\n</figure>\n"
 @test Weave.formatfigures(chunk, Weave.rst) == ".. figure:: figs/figures_plot1.png\n   :width: 100%\n\n   Nice plot\n\n"
 @test Weave.formatfigures(chunk, Weave.multimarkdown) == "![Nice plot][figs/figures_plot1.png]\n\n[figs/figures_plot1.png]: figs/figures_plot1.png width=100%\n"
@@ -31,11 +31,20 @@ chunk.options[:fig_cap] = "Nice plot"
 
 chunk.options[:label] = "somefig"
 @test Weave.formatfigures(chunk, Weave.pandoc) == "![Nice plot](figs/figures_plot1.png){width=100% #fig:somefig}\n"
-@test Weave.formatfigures(chunk, Weave.tex) == "\\begin{figure}[!h]\n\\center\n\\includegraphics[width=100%]{figs/figures_plot1.png}\n\\caption{Nice plot}\n\\label{fig:somefig}\n\\end{figure}\n"
+@test Weave.formatfigures(chunk, Weave.tex) == "\\begin{figure}[!h]\n\\center\n\\includegraphics[width=1.0\\linewidth]{figs/figures_plot1.png}\n\\caption{Nice plot}\n\\label{fig:somefig}\n\\end{figure}\n"
 @test Weave.formatfigures(chunk, Weave.tex) == Weave.formatfigures(chunk, Weave.md2tex)
 
 chunk.options[:label] = nothing
 chunk.options[:fig_cap] = nothing
 chunk.options[:fig_env] = "center"
 chunk.options[:fig_pos] = ""
-@test Weave.formatfigures(chunk, Weave.tex) == "\\begin{center}\n\\includegraphics[width=100%]{figs/figures_plot1.png}\n\\end{center}\n"
+@test Weave.formatfigures(chunk, Weave.tex) == "\\begin{center}\n\\includegraphics[width=1.0\\linewidth]{figs/figures_plot1.png}\n\\end{center}\n"
+
+chunk.options[:out_width] = "50%"
+chunk.options[:out_height] = "75 %"
+@test Weave.formatfigures(chunk, Weave.tex) == "\\begin{center}\n\\includegraphics[width=0.5\\linewidth,height=0.75\\paperheight]{figs/figures_plot1.png}\n\\end{center}\n"
+
+chunk.options[:out_width] = "A%"
+chunk.options[:out_height] = "0.5\\textwidth"
+@test Weave.formatfigures(chunk, Weave.tex) == "\\begin{center}\n\\includegraphics[width=A%,height=0.5\\textwidth]{figs/figures_plot1.png}\n\\end{center}\n"
+


### PR DESCRIPTION
Fixes #240. Changes the behavior for `fig_pos` beeing an empty string. Now emtpy `[]` aren't printed. For `fig_pos == nothing` this still defaults to `!h`.

To center every figure one can now use:
```
---
options:
      fig_env : center
      fig_pos : ""
---
```
without having `[]` after each figure.

~~Second thing I mention in #240 about the more generalized meaning of setting a length to a percentage (e.g 50 % gets translated to 0.5\linewidth for LaTeX) I'm not sure of anymore. 50 % in html means 50 % the image size, while my translation in LaTeX means 50 % the line width. So maybe a different syntax would be good here.~~
I was wrong, it's the same behavior in HTML so I will try to find a solution to that.