### PR TITLE
Fixed missing comma in example

### DIFF
--- a/doc/src/getting_started.md
+++ b/doc/src/getting_started.md
@@ -34,6 +34,6 @@ weave(joinpath(dirname(pathof(Weave)), "../examples", "FIR_design.jmd"),
   doctype = "md2pdf")
   #Markdown
 weave(joinpath(dirname(pathof(Weave)), "../examples", "FIR_design.jmd"),
-      doctype="pandoc"
+      doctype="pandoc",
       out_path=:pwd)
 ```


### PR DESCRIPTION
A comma was missing in the provided example