### PR TITLE
use 0.9em for code size instead of hard coding 13px

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Weave"
 uuid = "44d3d7a6-8a23-5bf8-98c5-b353f8df5ec9"
-version = "0.9.2"
+version = "0.9.3"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/templates/skeleton_css.css
+++ b/templates/skeleton_css.css
@@ -523,7 +523,7 @@ kbd,
 pre,
 samp {
   font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
-  font-size: 13px;
+  font-size: 0.9em;
 }
 
 


### PR DESCRIPTION
Currently the CSS file for HTML output hard codes all `<code>` output size as 13px.  When code is used in a header this leads to very small `<code>` text relative to the larger header.  

I propose using `0.9em` which makes the font a bit smaller than the surrounding elements; it seems to do a fine job of equalizing the subjective size in my local tests but I'm open to suggestions.

I've also bumped the patch version in Project.toml to 0.9.3 so this change could be released when merged.  I'm happy to change that as well if that's not standard practice here.