### PR TITLE
annotate collapsed cells with 'echo=false'

### DIFF
--- a/src/readers.jl
+++ b/src/readers.jl
@@ -269,6 +269,13 @@ function parse_doc(document::String, format::NotebookInput)
     srctext = "\n" * join(cell["source"], "")
 
     if cell["cell_type"] == "code"
+      if haskey(cell["metadata"], "jupyter")
+        if cell["metadata"]["jupyter"]["source_hidden"]
+          opt_string = " echo=false"
+        end
+      else
+        opt_string = ""
+      end
       chunk = CodeChunk(rstrip(srctext), codeno, 0, opt_string, options)
       push!(parsed, chunk)
       codeno += 1
@@ -278,8 +285,7 @@ function parse_doc(document::String, format::NotebookInput)
       docno +=1
     end
   end
-
-return parsed
+  return parsed
 end
 
 #Use this if regex is undefined


### PR DESCRIPTION
Hi there,

I noticed that so far `weave` and `convert_doc` ignored whether the jupyter notebook cell was collapsed or not.
This tiny PR annotates collapsed cells with `echo=false` during conversion to make sure that the source code will not show in the resulting markdown file.

Kind regards,
Jonas