### PR TITLE
Allow YAML header in output file

### DIFF
--- a/src/format.jl
+++ b/src/format.jl
@@ -24,7 +24,7 @@ function format(doc::WeaveDoc)
     #strip header
     if isa(doc.chunks[1], DocChunk)
         if !occursin("pandoc", doc.doctype)
-            doc.chunks[1] = strip_header(doc.chunks[1])
+            doc.chunks[1] = strip_header(doc.chunks[1], doc.header)
         end
     end
 
@@ -106,9 +106,13 @@ function render_doc(formatted, doc::WeaveDoc, format::JMarkdown2tex)
     [Pair(Symbol(k), v) for (k,v) in doc.header]...)
 end
 
-function strip_header(chunk::DocChunk)
+function strip_header(chunk::DocChunk, header)
   if occursin(r"^---$(?<header>.+)^---$"ms, chunk.content[1].content)
-    chunk.content[1].content = lstrip(replace(chunk.content[1].content, r"^---$(?<header>.+)^---$"ms => ""))
+    newheader = ""
+    if haskey(header, "output_header")
+        newheader = "---\n" *YAML.write(header["output_header"]) * "---"
+    end
+    chunk.content[1].content = lstrip(replace(chunk.content[1].content, r"^---$(?<header>.+)^---$"ms => newheader))
   end
   return chunk
 end

--- a/test/formatter_test.jl
+++ b/test/formatter_test.jl
@@ -151,3 +151,33 @@ parsed = doc_from_string(doc_content)
 ldoc = Weave.run(parsed, doctype = "md2tex",latex_keep_unicode=true)
 @test occursin("α",Weave.format(ldoc))
 @test !occursin(Weave.uc2tex("α"),Weave.format(ldoc))
+
+
+################################################################################
+#                           Test YAML in Target File                           #
+################################################################################
+
+let
+    content = """
+    ---
+        title: this does not appear
+        output_header:
+            author: My Name
+            title: this does appear
+    ---
+    # Here a title
+    """
+    output = """
+    ---
+    author: "My Name"
+    title: "this does appear"
+    ---
+    # Here a title
+    """
+    parsed = Weave.parse_doc(content,"markdown")
+    header = Weave.parse_header(parsed[1])
+    wdoc = Weave.WeaveDoc("",parsed,header)
+    doc = Weave.run(wdoc; doctype="github")
+    ldoc = Weave.format(doc)
+    @test ldoc == output
+end


### PR DESCRIPTION
Hi,

here's another small PR, this time concerning #197 .
I modified the function `strip_header`to look for a field called `output_header` in the YAML header given in the input file. If it exists, its contents are then reexported into YAML and added as a header for the output file.

A test is added as well.
What are your thoughts ? 
I have not added anything in the documentation yet because I wasn't sure where it would fit best.
