### PR TITLE
Keep latex figures [replaces #274]

### DIFF
--- a/src/Weave.jl
+++ b/src/Weave.jl
@@ -132,10 +132,10 @@ function weave(
     css != nothing && (doc.css = css)
 
     doc = run(doc, doctype = doctype,
-    mod = mod,
-    out_path=out_path, args = args,
-    fig_path = fig_path, fig_ext = fig_ext, cache_path = cache_path, cache=cache,
-    throw_errors = throw_errors,latex_keep_unicode=latex_keep_unicode)
+                mod = mod,
+                out_path=out_path, args = args,
+                fig_path = fig_path, fig_ext = fig_ext, cache_path = cache_path, cache=cache,
+                throw_errors = throw_errors,latex_keep_unicode=latex_keep_unicode)
     formatted = format(doc)
 
     outname = get_outname(out_path, doc)

--- a/src/Weave.jl
+++ b/src/Weave.jl
@@ -131,49 +131,39 @@ function weave(
     #theme != nothing && (doc.theme = theme) #Reserved for themes
     css != nothing && (doc.css = css)
 
-    try
-      doc = run(doc, doctype = doctype,
-              mod = mod,
-              out_path=out_path, args = args,
-              fig_path = fig_path, fig_ext = fig_ext, cache_path = cache_path, cache=cache,
-              throw_errors = throw_errors,latex_keep_unicode=latex_keep_unicode)
-      formatted = format(doc)
+    doc = run(doc, doctype = doctype,
+    mod = mod,
+    out_path=out_path, args = args,
+    fig_path = fig_path, fig_ext = fig_ext, cache_path = cache_path, cache=cache,
+    throw_errors = throw_errors,latex_keep_unicode=latex_keep_unicode)
+    formatted = format(doc)
 
-      outname = get_outname(out_path, doc)
+    outname = get_outname(out_path, doc)
 
-      open(outname, "w") do io
-          write(io, formatted)
-      end
-
-      #Special for that need external programs
-      if doc.doctype == "pandoc2html"
-          mdname = outname
-          outname = get_outname(out_path, doc, ext = "html")
-          pandoc2html(formatted, doc, outname, pandoc_options)
-          rm(mdname)
-      elseif doc.doctype == "pandoc2pdf"
-          mdname = outname
-          outname = get_outname(out_path, doc, ext = "pdf")
-          pandoc2pdf(formatted, doc, outname, pandoc_options)
-          rm(mdname)
-      elseif doc.doctype == "md2pdf"
-          success = run_latex(doc, outname, latex_cmd)
-          success && rm(doc.fig_path, force = true, recursive = true)
-          success || return
-          outname = get_outname(out_path, doc, ext = "pdf")
-      end
-
-      doc.cwd == pwd() && (outname = basename(outname))
-      @info "Report weaved to $outname"
-      return abspath(outname)
-    # catch err
-    #    @warn "Something went wrong during weaving"
-    #    @error sprint(showerror, err)
-    #    return nothing
-    finally
-        doctype == :auto && (doctype = detect_doctype(doc.source))
-        occursin(r"2(pdf|html)", doctype) && rm(doc.fig_path, force = true, recursive = true)
+    open(outname, "w") do io
+        write(io, formatted)
     end
+
+    #Special for that need external programs
+    if doc.doctype == "pandoc2html"
+        mdname = outname
+        outname = get_outname(out_path, doc, ext = "html")
+        pandoc2html(formatted, doc, outname, pandoc_options)
+        rm(mdname)
+    elseif doc.doctype == "pandoc2pdf"
+        mdname = outname
+        outname = get_outname(out_path, doc, ext = "pdf")
+        pandoc2pdf(formatted, doc, outname, pandoc_options)
+        rm(mdname)
+    elseif doc.doctype == "md2pdf"
+        success = run_latex(doc, outname, latex_cmd)
+        success || return
+        outname = get_outname(out_path, doc, ext = "pdf")
+    end
+
+    doc.cwd == pwd() && (outname = basename(outname))
+    @info("Report weaved to $outname")
+    return abspath(outname)
 end
 
 weave(doc::AbstractString, doctype::Union{Symbol,AbstractString}) =

--- a/src/pandoc.jl
+++ b/src/pandoc.jl
@@ -108,7 +108,7 @@ function run_latex(doc::WeaveDoc, outname, latex_cmd = "xelatex")
   old_wd = pwd()
   cd(doc.cwd)
   xname = basename(outname)
-  @info("Weaved code to $outname. Running $latex_cmd")
+  @info("Weaved code to $outname . Running $latex_cmd") # space before '.' added for link to be clickable in Juno terminal
   textmp = mktempdir(".")
   try
     out = read(`$latex_cmd -shell-escape $xname -aux-directory $textmp -include-directory $(doc.cwd)`, String)


### PR DESCRIPTION
This PR addresses #273 and is a replacement of #274 

I never saw a reason to discard the figures, maybe space saving in the tmp folder?

If the figures are kept, one can manually recompile the document if one wants to change something, or if automatic compilation failed.

The diff looks larger than it really is since I removed a try-catch and therefore changed indentation.