### PR TITLE
more graceful header handling

### DIFF
--- a/src/format.jl
+++ b/src/format.jl
@@ -21,12 +21,7 @@ function format(doc::WeaveDoc)
     docformat.formatdict[:cwd] = doc.cwd #pass wd to figure formatters
     docformat.formatdict[:theme] = doc.highlight_theme
 
-    #strip header
-    if isa(doc.chunks[1], DocChunk)
-        if !occursin("pandoc", doc.doctype)
-            doc.chunks[1] = strip_header(doc.chunks[1])
-        end
-    end
+    strip_header!(doc)
 
     for chunk in copy(doc.chunks)
         result = format_chunk(chunk, formatdict, docformat)
@@ -106,12 +101,27 @@ function render_doc(formatted, doc::WeaveDoc, format::JMarkdown2tex)
     [Pair(Symbol(k), v) for (k,v) in doc.header]...)
 end
 
-function strip_header(chunk::DocChunk)
-  if occursin(r"^---$(?<header>.+)^---$"ms, chunk.content[1].content)
-    chunk.content[1].content = lstrip(replace(chunk.content[1].content, r"^---$(?<header>.+)^---$"ms => ""))
-  end
-  return chunk
+strip_header!(doc::WeaveDoc) = strip_header!(doc.chunks[1], doc.doctype)
+function strip_header!(docchunk::DocChunk, doctype)
+    doctype == "pandoc" && return
+    content = docchunk.content[1].content
+    docchunk.content[1].content = if (m = match(HEADER_REGEX, content)) !== nothing
+        # TODO: is there other format where we want to keep headers ?
+        if doctype != "github"
+            lstrip(replace(content, HEADER_REGEX => ""))
+        else
+            # only strips Weave headers
+            header = YAML.load(m[:header])
+            delete!(header, "options")
+            if isempty(header)
+                lstrip(replace(content, HEADER_REGEX => ""))
+            else
+                lstrip(replace(content, HEADER_REGEX => "---\n$(YAML.write(header))---"))
+            end
+        end
+    end
 end
+strip_header!(codechunk::CodeChunk, doctype) = nothing
 
 function format_chunk(chunk::DocChunk, formatdict, docformat)
     return join([format_inline(c) for c in chunk.content], "")

--- a/src/format.jl
+++ b/src/format.jl
@@ -105,9 +105,9 @@ strip_header!(doc::WeaveDoc) = strip_header!(doc.chunks[1], doc.doctype)
 function strip_header!(docchunk::DocChunk, doctype)
     doctype == "pandoc" && return
     content = docchunk.content[1].content
-    docchunk.content[1].content = if (m = match(HEADER_REGEX, content)) !== nothing
+    if (m = match(HEADER_REGEX, content)) !== nothing
         # TODO: is there other format where we want to keep headers ?
-        if doctype != "github"
+        docchunk.content[1].content = if doctype != "github"
             lstrip(replace(content, HEADER_REGEX => ""))
         else
             # only strips Weave headers

--- a/src/readers.jl
+++ b/src/readers.jl
@@ -64,8 +64,10 @@ function parse_header(chunk::CodeChunk)
   return Dict()
 end
 
+const HEADER_REGEX = r"^---$(?<header>((?!---).)+)^---$"ms
+
 function parse_header(chunk::DocChunk)
-  m = match(r"^---$(?<header>.+)^---$"ms, chunk.content[1].content)
+  m = match(HEADER_REGEX, chunk.content[1].content)
   if m !== nothing
     header = YAML.load(string(m[:header]))
   else

--- a/src/writers.jl
+++ b/src/writers.jl
@@ -83,7 +83,7 @@ function convert_doc(doc::WeaveDoc, format::NotebookOutput)
     """
 
     if isa(doc.chunks[1], DocChunk)
-        doc.chunks[1] = strip_header(doc.chunks[1])
+        strip_header!(doc)
         doc.chunks[1].content[1].content = Mustache.render(head_tpl;
               [Pair(Symbol(k), v) for (k,v) in doc.header]...) * doc.chunks[1].content[1].content
     end

--- a/test/formatter_test.jl
+++ b/test/formatter_test.jl
@@ -72,14 +72,14 @@ h = Weave.parse_header(dchunk)
 h_ref = Dict("author" => "Matti Pastell", "title" => "Test block")
 @test h_ref == h
 
-htext = Weave.strip_header(dchunk)
+Weave.strip_header!(dchunk, "md2html")
 h_ref = """
 # Actual header
 
 and some text
 
 """
-@test htext.content[1].content == h_ref
+@test dchunk.content[1].content == h_ref
 
 # Test wrapping
 


### PR DESCRIPTION
fixes #197 

basically, this PR only changes the behavior when the output type is `github` (markdown).
When generating markdown, we _only_ strips Weave header (i.e. `options`) and preserver all the other headers.

This PR also improves the regex to match YAML Header so that it will fix #304 as well