### PR TITLE
limit display:

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,10 +27,11 @@ julia = "1"
 [extras]
 Cairo = "159f3aea-2a34-519c-b102-8c37f9878175"
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Gadfly = "c91e804a-d5a3-530f-b6f0-dfbca275c004"
 IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Plots", "Gadfly", "Cairo", "Conda", "IJulia"]
+test = ["Cairo", "Conda", "DataFrames", "Gadfly", "IJulia", "Plots", "Test"]

--- a/src/display_methods.jl
+++ b/src/display_methods.jl
@@ -86,7 +86,7 @@ Base.display(report::Report, m::MIME"application/pdf", data) = add_figure(report
 # Text is written to stdout, called from "term" mode chunks
 function Base.display(report::Report, m::MIME"text/plain", data)
     io = PipeBuffer()
-    show(IOContext(io, :limit => true, :color => true), m, data)
+    show(IOContext(io, :limit => true), m, data)
     flush(io)
     s = read(io, String)
     close(io)
@@ -110,7 +110,7 @@ end
 # Catch "rich_output"
 function Base.display(report::Report, m::MIME"text/html", data)
     io = IOBuffer()
-    show(IOContext(io, :limit => true, :color => true), m, data)
+    show(IOContext(io, :limit => true), m, data)
     report.rich_output *= "\n" * String(take!(io))
 end
 

--- a/src/display_methods.jl
+++ b/src/display_methods.jl
@@ -83,10 +83,10 @@ Base.display(report::Report, m::MIME"image/svg+xml", data) = add_figure(report, 
 
 Base.display(report::Report, m::MIME"application/pdf", data) = add_figure(report, data, m, ".pdf")
 
-#Text is written to stdout, called from "term" mode chunks
+# Text is written to stdout, called from "term" mode chunks
 function Base.display(report::Report, m::MIME"text/plain", data)
     io = PipeBuffer()
-    show(IOContext(io, :limit => true), m, data)
+    show(IOContext(io, :limit => true, :color => true), m, data)
     flush(io)
     s = read(io, String)
     close(io)
@@ -107,13 +107,14 @@ function Base.show(io, m::MIME"text/html", data::Exception)
     println(io, "</pre>")
 end
 
-#Catch "rich_output"
+# Catch "rich_output"
 function Base.display(report::Report, m::MIME"text/html", data)
-    s = repr(m, data)
-    report.rich_output *= "\n" * s
+    io = IOBuffer()
+    show(IOContext(io, :limit => true, :color => true), m, data)
+    report.rich_output *= "\n" * String(take!(io))
 end
 
-#Catch "rich_output"
+# Catch "rich_output"
 function Base.display(report::Report, m::MIME"text/markdown", data)
     s = repr(m, data)
     # Convert to "richer" type of possible

--- a/test/formatter_test.jl
+++ b/test/formatter_test.jl
@@ -108,13 +108,13 @@ str = """
 """
 
 let
-    doc = run_doc(mock_doc(str), doctype = "md2tex")
+    doc = mock_doc(str; doctype = "md2tex")
     @test occursin(Weave.uc2tex("α"), Weave.format(doc))
     @test !occursin("α", Weave.format(doc))
 end
 
 let
-    doc = run_doc(mock_doc(str), doctype = "md2tex",latex_keep_unicode = true)
+    doc = mock_doc(str; doctype = "md2tex", latex_keep_unicode = true)
     @test occursin("α", Weave.format(doc))
     @test !occursin(Weave.uc2tex("α"), Weave.format(doc))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,12 +5,14 @@ using Weave: WeaveDoc, run_doc
 # TODO: add test for header processsing
 # TODO: add test for `include_weave`
 
-# constructs `WeaveDoc` from `String`
-function mock_doc(str, format = "markdown")
+# constructs `WeaveDoc` from `String` and run it
+function mock_doc(str; informat = "markdown", run = true, doctype = "md2html", kwargs...)
     f = tempname()
     write(f, str)
-    return WeaveDoc(f, format)
+    doc = WeaveDoc(f, informat)
+    return run ? run_doc(doc; doctype = doctype, kwargs...) : doc
 end
+macro jmd_str(s) mock_doc(s) end
 
 
 @testset "Weave" begin
@@ -32,6 +34,10 @@ end
 
     @testset "conversions" begin
         include("test_converter.jl")
+    end
+
+    @testset "display" begin
+        include("test_display.jl")
     end
 
     @testset "Formatters" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,7 +30,7 @@ end
         include("test_error_rendering.jl")
     end
 
-    @testset "convertions" begin
+    @testset "conversions" begin
         include("test_converter.jl")
     end
 

--- a/test/test_display.jl
+++ b/test/test_display.jl
@@ -1,0 +1,28 @@
+@testset "limit HMTL output" begin
+
+@static VERSION ≥ v"1.4" && let
+
+# no limit
+doc = jmd"""
+```julia
+using DataFrames
+DataFrame(rand(10,3))
+```
+"""
+@test isdefined(doc.chunks[1], :rich_output)
+@test count("<tr>", doc.chunks[1].rich_output) == 12 # additonal 2 for name and type row
+
+# limit
+n = 100000
+doc = jmd"""
+```julia
+using DataFrames
+DataFrame(rand(n,3))
+```
+"""
+@test isdefined(doc.chunks[1], :rich_output)
+@test count("<tr>", doc.chunks[1].rich_output) < n
+
+end
+
+end

--- a/test/test_error_rendering.jl
+++ b/test/test_error_rendering.jl
@@ -35,7 +35,7 @@ err_str3_1 = get_err_str("plot(x)")
 err_str3_2 = get_err_str("f(y")
 
 
-let doc = run_doc(mock_doc(str), doctype = "pandoc")
+let doc = mock_doc(str; doctype = "github")
     get_output(i) = doc.chunks[i].output
 
     @test occursin(err_str1, get_output(1))
@@ -44,6 +44,6 @@ let doc = run_doc(mock_doc(str), doctype = "pandoc")
     @test occursin(err_str3_2, get_output(3))
 end
 
-@test_throws ArgumentError run_doc(mock_doc(str), doctype = "pandoc", throw_errors = true)
+@test_throws ArgumentError mock_doc(str; doctype = "github", throw_errors = true)
 
 # TODO: test error rendering in `rich_output`

--- a/test/test_header.jl
+++ b/test/test_header.jl
@@ -47,7 +47,6 @@ let
     title: No. `j 1`
     ---
     """)
-    run_doc(d)
     @test d.header["title"] == "No. 1"
 end
 
@@ -60,8 +59,7 @@ let
     ---
     title: No. `j n`
     ---
-    """)
-    run_doc(d; mod = m)
+    """; mod = m)
     @test d.header["title"] == "No. 1"
 
     # strip quotes by default
@@ -70,8 +68,7 @@ let
     ---
     title: No. `j s`
     ---
-    """)
-    run_doc(d; mod = m)
+    """; mod = m)
     @test d.header["title"] == "No. 1" # otherwise `"No. "1""`
 end
 

--- a/test/test_module_evaluation.jl
+++ b/test/test_module_evaluation.jl
@@ -1,6 +1,6 @@
 @testset "evaluation module" begin
     function mock_output(str, mod = nothing)
-        result_doc = run_doc(mock_doc(str), mod = mod)
+        result_doc = mock_doc(str; mod = mod)
         return result_doc.chunks[1].output
     end
 


### PR DESCRIPTION
- for now if we try to render a "big object" like a table with many 
rows, Weave tries to render all of the result and it can lead to that a 
document can't even be opened
