### PR TITLE
[RFC] Do not define Markdown.latex using eval

### DIFF
--- a/src/WeaveMarkdown/markdown.jl
+++ b/src/WeaveMarkdown/markdown.jl
@@ -5,23 +5,15 @@ using ..Weave: isnothing, take2string!
 using Markdown
 import Markdown: @trigger, @breaking, Code, MD, withstream, startswith, LaTeX
 
-
-function __init__()
-    # NOTE:
-    # overwriting `Markdown.latex` function should be done here in order to allow
-    # incremental precompilations
-    Markdown.eval(
-        quote
-            function latex(io::IO, tex::Markdown.LaTeX)
-                math_envs = ["align", "equation", "eqnarray"]
-                use_dollars =
-                    !any([occursin("\\begin{$me", tex.formula) for me in math_envs])
-                use_dollars && write(io, "\\[")
-                write(io, string("\n", tex.formula, "\n"))
-                use_dollars && write(io, "\\]\n")
-            end
-        end,
-    )
+# Note that this definition causes a "Method overwritten" warning,
+# but defining this function in __init__() is not legal in julia v1.5
+function Markdown.latex(io::IO, tex::Markdown.LaTeX)
+    math_envs = ["align", "equation", "eqnarray"]
+    use_dollars =
+        !any([occursin("\\begin{$me", tex.formula) for me in math_envs])
+    use_dollars && write(io, "\\[")
+    write(io, string("\n", tex.formula, "\n"))
+    use_dollars && write(io, "\\]\n")
 end
 
 mutable struct Comment


### PR DESCRIPTION
This PR solves #356 at the expense of a warning:
```
WARNING: Method definition latex(IO, Markdown.LaTeX) in module Markdown at /home/fredrikb/julia/usr/share/julia/stdlib/v1.5/Markdown/src/IPython/IPython.jl:28 overwritten in module WeaveMarkdown at /home/fredrikb/.julia/dev/Weave/src/WeaveMarkdown/markdown.jl:10.
  ** incremental compilation may be fatally broken for this module **
```