### PR TITLE
Introducing a SecondaryFormat for external rendering

### DIFF
--- a/src/Weave.jl
+++ b/src/Weave.jl
@@ -192,9 +192,15 @@ function weave(
         highlight_theme = get(weave_options, "highlight_theme", highlight_theme)
         latex_cmd = get(weave_options, "latex_cmd", latex_cmd)
         keep_unicode = get(weave_options, "keep_unicode", keep_unicode)
+        pandoc_options = get(weave_options, "pandoc_options", pandoc_options)
     end
 
-    set_rendering_options!(doc; template = template, highlight_theme = highlight_theme, css = css, keep_unicode = keep_unicode)
+    set_rendering_options!(doc; template = template,
+                                highlight_theme = highlight_theme,
+                                css = css,
+                                keep_unicode = keep_unicode,
+                                options = pandoc_options,
+                                latex_cmd = latex_cmd)
     rendered = render_doc(doc)
 
     out_path = get_out_path(doc, out_path)
@@ -202,26 +208,7 @@ function weave(
 
     # document generation via external programs
     # -----------------------------------------
-
-    if !isnothing(weave_options)
-        pandoc_options = get(weave_options, "pandoc_options", pandoc_options)
-    end
-
-    doctype = doc.doctype
-    if doctype == "pandoc2html"
-        intermediate = out_path
-        out_path = get_out_path(doc, out_path, "html")
-        pandoc2html(rendered, doc, highlight_theme, out_path, pandoc_options)
-        rm(intermediate)
-    elseif doctype == "pandoc2pdf"
-        intermediate = out_path
-        out_path = get_out_path(doc, out_path, "pdf")
-        pandoc2pdf(rendered, doc, out_path, pandoc_options)
-        rm(intermediate)
-    elseif doctype == "md2pdf"
-        run_latex(doc, out_path, latex_cmd)
-        out_path = get_out_path(doc, out_path, "pdf")
-    end
+    out_path = postprocessing(doc, out_path)
 
     @info "Weaved to $(out_path)"
     return out_path

--- a/src/rendering/htmlformats.jl
+++ b/src/rendering/htmlformats.jl
@@ -144,7 +144,12 @@ Base.@kwdef mutable struct Pandoc2HTML <: HTMLFormat
     out_height = nothing
     fig_pos = nothing
     fig_env = nothing
+    highlight_theme = nothing
 end
 register_format!("pandoc2html", Pandoc2HTML())
 
 formatfigures(chunk, docformat::Pandoc2HTML) = formatfigures(chunk, Pandoc())
+
+function set_rendering_options!(docformat::Pandoc2HTML; highlight_theme = nothing, kwargs...)
+    docformat.highlight_theme = get_highlight_theme(highlight_theme)
+end

--- a/src/rendering/rendering.jl
+++ b/src/rendering/rendering.jl
@@ -27,6 +27,7 @@ function render_doc(doc::WeaveDoc)
 end
 
 
+include("secondaryformats.jl")
 include("common.jl")
 include("htmlformats.jl")
 include("texformats.jl")

--- a/src/rendering/secondaryformats.jl
+++ b/src/rendering/secondaryformats.jl
@@ -1,0 +1,88 @@
+abstract type SecondaryFormat <: WeaveFormat end
+abstract type PDF <: SecondaryFormat end
+
+function Base.getproperty(sf::SecondaryFormat, s::Symbol)
+    hasfield(typeof(sf), s) && return getfield(sf, s)
+    return getproperty(sf.primaryformat, s)
+end
+function Base.setproperty!(sf::SecondaryFormat, s::Symbol, v)
+    if hasfield(typeof(sf), s)
+        setfield!(sf, s, v)
+    else
+        setproperty!(sf.primaryformat, s, v)
+    end
+end
+function Base.hasproperty(sf::SecondaryFormat, s::Symbol)
+    hasfield(typeof(sf), s) || hasfield(typeof(sf.primaryformat), s)
+end
+
+format_chunk(chunk::DocChunk, docformat::SecondaryFormat) =
+    format_chunk(chunk, docformat.primaryformat)
+
+formatfigures(chunk, sf::SecondaryFormat) =
+    formatfigures(chunk, sf.primaryformat)
+
+format_code(code, sf::SecondaryFormat) =
+    format_code(code, sf.primaryformat)
+
+format_termchunk(chunk, sf::SecondaryFormat) =
+    format_termchunk(chunk, sf.primaryformat)
+
+format_output(result, sf::SecondaryFormat) =
+    format_output(result, sf.primaryformat)
+
+render_doc(docformat::SecondaryFormat, body, doc) =
+    render_doc(docformat.primaryformat, body, doc)
+
+
+postprocessing(doc, out_path) = postprocessing(doc.format, doc, out_path)
+postprocessing(::WeaveFormat, doc, out_path) = out_path
+
+postprocessing(docformat::SecondaryFormat, doc, out_path) =
+    postprocessing(docformat, docformat.primaryformat, doc, out_path)
+
+
+function set_rendering_options!(sf::SecondaryFormat; kwargs...)
+    for (key, val) in pairs(kwargs)
+        if hasfield(typeof(sf), key)
+            setproperty!(sf, key, val)
+        end
+    end
+    set_rendering_options!(sf.primaryformat; kwargs...)
+end
+
+Base.@kwdef mutable struct LatexPDF <: PDF
+    primaryformat
+    latex_cmd = "xelatex"
+end
+
+function postprocessing(sf::LatexPDF, _, doc, out_path)
+    run_latex(doc, out_path, sf.latex_cmd)
+    out_path = get_out_path(doc, out_path, "pdf")
+end
+
+Base.@kwdef mutable struct PandocPDF <: PDF
+    primaryformat
+    options
+end
+
+function postprocessing(sf::PandocPDF, df, doc, out_path)
+    intermediate = out_path
+    out_path = get_out_path(doc, out_path, "pdf")
+    pandoc2pdf(read(intermediate, String), doc, out_path, sf.options)
+    rm(intermediate)
+    out_path
+end
+
+mutable struct PandocHTML <: SecondaryFormat
+    primaryformat
+    options
+end
+
+function postprocessing(sf::PandocHTML, df, doc)
+    intermediate = out_path
+    out_path = get_out_path(doc, out_path, "html")
+    pandoc2html(read(intermediate, String), doc, sf.highlight_theme, out_path, sf.options)
+    rm(intermediate)
+    out_path
+end

--- a/src/rendering/texformats.jl
+++ b/src/rendering/texformats.jl
@@ -171,7 +171,7 @@ Base.@kwdef mutable struct TexMinted <: TexFormat
     escape_closer = reverse(escape_starter)
 end
 register_format!("texminted", TexMinted())
-
+register_format!("mintedpdf", LatexPDF(TexMinted(), "xelatex --shell-escape"))
 # Tex (directly to PDF)
 # ---------------------
 
@@ -198,10 +198,10 @@ Base.@kwdef mutable struct JMarkdown2PDF <: TexFormat
     tex_deps = ""
     # how to escape latex in verbatim/code environment
     escape_starter = "(*@"
-    escape_closer = reverse(escape_starter)
+    escape_closer = "@*)"
 end
 register_format!("md2tex", JMarkdown2PDF())
-register_format!("md2pdf", JMarkdown2PDF())
+register_format!("md2pdf", LatexPDF(JMarkdown2PDF(), "xelatex"))
 
 function set_rendering_options!(docformat::JMarkdown2PDF; template = nothing, highlight_theme = nothing, keep_unicode = false, kwargs...)
     docformat.template = get_tex_template(template)


### PR DESCRIPTION
Hi,
as speculated in my previous PR I implemented an idea to
make external rendering such as `md2pdf` or `pandoc2pdf` etc. 
work just as a regular `WeaveFormat`.
A `SecondaryFormat` wraps a primary `WeaveFormat` that does the hard work.
In the very end of the `weave` function there is now a little call
`postprocessing(doc, out_path)`
that does nothing if the format is one of the normal formats but dispatches to the 
external rendering if a `LatexPDF, `PandocPDF`, or `PandocHTML` has been passed.


@aviatesk 
You seem to have been working on these files at the same time but I decided to create PR instead of first trying to fix the merge requests.
The current implementation already works quite well so maybe you could have a look at it to see if it is worth cleaning up.