### PR TITLE
Export formats as wrapper

### DIFF
--- a/src/rendering/exportformat.jl
+++ b/src/rendering/exportformat.jl
@@ -1,18 +1,18 @@
 abstract type ExportFormat <: WeaveFormat end
 
-function Base.getproperty(sf::ExportFormat, s::Symbol)
-    hasfield(typeof(sf), s) && return getfield(sf, s)
+function Base.getproperty(sf::T, s::Symbol) where {T<:ExportFormat}
+    hasfield(T, s) && return getfield(sf, s)
     return getproperty(sf.primaryformat, s)
 end
-function Base.setproperty!(sf::ExportFormat, s::Symbol, v)
-    if hasfield(typeof(sf), s)
+function Base.setproperty!(sf::T, s::Symbol, v) where {T<:ExportFormat}
+    if hasfield(T, s)
         setfield!(sf, s, v)
     else
         setproperty!(sf.primaryformat, s, v)
     end
 end
-function Base.hasproperty(sf::ExportFormat, s::Symbol)
-    hasfield(typeof(sf), s) || hasfield(typeof(sf.primaryformat), s)
+function Base.hasproperty(sf::T, s::Symbol) where {T<:ExportFormat}
+    hasfield(T, s) || hasproperty(sf.primaryformat, s)
 end
 
 render_doc(df::ExportFormat, body, doc) = render_doc(df.primaryformat, body, doc)

--- a/src/rendering/exportformat.jl
+++ b/src/rendering/exportformat.jl
@@ -1,0 +1,24 @@
+abstract type ExportFormat <: WeaveFormat end
+
+function Base.getproperty(sf::ExportFormat, s::Symbol)
+    hasfield(typeof(sf), s) && return getfield(sf, s)
+    return getproperty(sf.primaryformat, s)
+end
+function Base.setproperty!(sf::ExportFormat, s::Symbol, v)
+    if hasfield(typeof(sf), s)
+        setfield!(sf, s, v)
+    else
+        setproperty!(sf.primaryformat, s, v)
+    end
+end
+function Base.hasproperty(sf::ExportFormat, s::Symbol)
+    hasfield(typeof(sf), s) || hasfield(typeof(sf.primaryformat), s)
+end
+
+render_doc(df::ExportFormat, body, doc) = render_doc(df.primaryformat, body, doc)
+
+render_chunk(df::ExportFormat, chunk) = render_chunk(df.primaryformat, chunk)
+# Need to define these to avoid ambiguities
+render_chunk(df::ExportFormat, chunk::DocChunk) = render_chunk(df.primaryformat, chunk)
+render_chunk(df::ExportFormat, chunk::CodeChunk) = render_chunk(df.primaryformat, chunk)
+render_output(df::ExportFormat, output) = render_output(df.primaryformat, output)

--- a/src/rendering/htmlformats.jl
+++ b/src/rendering/htmlformats.jl
@@ -143,4 +143,4 @@ function set_format_options!(docformat::Pandoc2HTML; template = nothing, css = n
     docformat.pandoc_options = pandoc_options
 end
 
-#render_figures(docformat::Pandoc2HTML, chunk) = render_figures(Pandoc(), chunk)
+render_figures(docformat::Pandoc2HTML, chunk) = render_figures(Pandoc(), chunk)

--- a/src/rendering/htmlformats.jl
+++ b/src/rendering/htmlformats.jl
@@ -124,23 +124,9 @@ end
 # Pandoc
 # ------
 
-Base.@kwdef mutable struct Pandoc2HTML <: HTMLFormat
+Base.@kwdef mutable struct Pandoc2HTML <: ExportFormat
     description = "HTML via intermediate Pandoc Markdown (requires Pandoc 2)"
-    extension = "md"
-    codestart = "\n"
-    codeend = "\n"
-    termstart = codestart
-    termend = codeend
-    outputstart = "\n"
-    outputend = "\n"
-    mimetypes = ["image/png", "image/svg+xml", "image/jpg", "text/html", "text/markdown", "text/plain"]
-    fig_ext = ".png"
-    out_width = nothing
-    out_height = nothing
-    fig_pos = nothing
-    fig_env = nothing
-    # specials
-    preserve_header = true
+    primaryformat = Pandoc()
     template_path = nothing
     stylesheet_path = nothing
     highlight_theme = nothing
@@ -157,4 +143,4 @@ function set_format_options!(docformat::Pandoc2HTML; template = nothing, css = n
     docformat.pandoc_options = pandoc_options
 end
 
-render_figures(docformat::Pandoc2HTML, chunk) = render_figures(Pandoc(), chunk)
+#render_figures(docformat::Pandoc2HTML, chunk) = render_figures(Pandoc(), chunk)

--- a/src/rendering/pandocformats.jl
+++ b/src/rendering/pandocformats.jl
@@ -54,28 +54,14 @@ Base.@kwdef mutable struct Pandoc <: PandocFormat
 end
 register_format!("pandoc", Pandoc())
 
+
 const DEFAULT_PANDOC_OPTIONS = String[]
 
-Base.@kwdef mutable struct Pandoc2PDF <: PandocFormat
+Base.@kwdef mutable struct Pandoc2PDF <: ExportFormat
     description = "PDF via intermediate Pandoc Markdown"
-    extension = "md"
-    codestart = "~~~~{.julia}"
-    codeend = "~~~~~~~~~~~~~\n\n"
-    termstart = codestart
-    termend = codeend
-    outputstart = "~~~~"
-    outputend = "~~~~\n\n"
-    # Prefer png figures for markdown conversion, svg doesn't work with latex
-    mimetypes = ["image/png", "image/jpg", "image/svg+xml", "text/markdown", "text/plain"]
-    fig_ext = ".png"
-    out_width = nothing
-    out_height = nothing
-    fig_pos = nothing
-    fig_env = nothing
-    # specials
-    preserve_header = true
-    header_template = normpath(TEMPLATE_DIR, "pandoc2pdf_header.txt")
+    primaryformat = Pandoc()
     pandoc_options = DEFAULT_PANDOC_OPTIONS
+    header_template = normpath(TEMPLATE_DIR, "pandoc2pdf_header.txt")
 end
 register_format!("pandoc2pdf", Pandoc2PDF())
 

--- a/src/rendering/rendering.jl
+++ b/src/rendering/rendering.jl
@@ -23,9 +23,9 @@ function render_doc(doc::WeaveDoc)
     return render_doc(docformat, body, doc)
 end
 
-
+include("exportformat.jl")
 include("common.jl")
+include("pandocformats.jl")
 include("htmlformats.jl")
 include("texformats.jl")
-include("pandocformats.jl")
 include("miscformats.jl")

--- a/src/rendering/texformats.jl
+++ b/src/rendering/texformats.jl
@@ -34,7 +34,10 @@ render_output(docformat::LaTeXFormat, output) = unicode2latex(docformat, output,
 
 render_code(docformat::LaTeXFormat, code) = unicode2latex(docformat, code, true)
 
-render_termchunk(docformat::LaTeXFormat, chunk) = string(docformat.termstart, chunk.output, docformat.termend, "\n")
+render_termchunk(docformat::LaTeXFormat, chunk) =
+    string(docformat.termstart,
+            unicode2latex(docformat, chunk.output, true),
+            docformat.termend, "\n")
 
 # from julia symbols (e.g. "\bfhoge") to valid latex
 const UNICODE2LATEX = let
@@ -198,8 +201,14 @@ function render_code(docformat::WeaveLaTeXFormat, code)
     unicode2latex(docformat, ret, false)
 end
 
-render_termchunk(docformat::WeaveLaTeXFormat, chunk) =
-    should_render(chunk) ? highlight_term(MIME("text/latex"), chunk.output, docformat.highlight_theme) : ""
+function render_termchunk(docformat::WeaveLaTeXFormat, chunk)
+    if should_render(chunk)
+        ret = highlight_term(MIME("text/latex"), chunk.output, docformat.highlight_theme)
+        unicode2latex(docformat, ret, true)
+    else
+        ""
+    end
+end
 
 function render_doc(docformat::WeaveLaTeXFormat, body, doc)
     return Mustache.render(

--- a/src/rendering/texformats.jl
+++ b/src/rendering/texformats.jl
@@ -250,7 +250,7 @@ register_format!("md2tex", WeaveLaTeX())
 const DEFAULT_LATEX_CMD = ["xelatex", "-shell-escape", "-halt-on-error"]
 
 
-Base.@kwdef mutable struct LaTeX2PDF <: LaTeXFormat
+Base.@kwdef mutable struct LaTeX2PDF <: ExportFormat
     primaryformat = WeaveLaTeX()
     description = "PDF via LaTeX"
     latex_cmd = DEFAULT_LATEX_CMD
@@ -258,29 +258,7 @@ end
 register_format!("md2pdf", LaTeX2PDF())
 register_format!("minted2pdf", LaTeX2PDF(primaryformat=LaTeXMinted()))
 
-function Base.getproperty(sf::LaTeX2PDF, s::Symbol)
-    hasfield(typeof(sf), s) && return getfield(sf, s)
-    return getproperty(sf.primaryformat, s)
-end
-function Base.setproperty!(sf::LaTeX2PDF, s::Symbol, v)
-    if hasfield(typeof(sf), s)
-        setfield!(sf, s, v)
-    else
-        setproperty!(sf.primaryformat, s, v)
-    end
-end
-function Base.hasproperty(sf::LaTeX2PDF, s::Symbol)
-    hasfield(typeof(sf), s) || hasfield(typeof(sf.primaryformat), s)
-end
-
 function set_format_options!(docformat::LaTeX2PDF; latex_cmd = DEFAULT_LATEX_CMD, _kwargs...)
     docformat.latex_cmd = latex_cmd
     set_format_options!(docformat.primaryformat; _kwargs...)
 end
-
-render_doc(df::LaTeX2PDF, body, doc) = render_doc(df.primaryformat, body, doc)
-
-render_chunk(df::LaTeX2PDF, chunk) = render_chunk(df.primaryformat, chunk)
-# Need to define these to avoid ambiguities
-render_chunk(df::LaTeX2PDF, chunk::DocChunk) = render_chunk(df.primaryformat, chunk)
-render_chunk(df::LaTeX2PDF, chunk::CodeChunk) = render_chunk(df.primaryformat, chunk)

--- a/src/writer/latex.jl
+++ b/src/writer/latex.jl
@@ -1,4 +1,4 @@
-function write_doc(docformat::WeaveLaTeX2PDF, doc, rendered, out_path)
+function write_doc(docformat::LaTeX2PDF, doc, rendered, out_path)
     cd_back = let d = pwd(); () -> cd(d); end
     cd(doc.cwd)
     try

--- a/test/end2end/test_simple.jl
+++ b/test/end2end/test_simple.jl
@@ -3,7 +3,7 @@ using Weave.Dates
 
 test_doctypes = filter(first.(Weave.list_out_formats())) do doctype
     # don't test doctypes which need external programs
-    doctype ∉ ("pandoc2html", "pandoc2pdf", "md2pdf")
+    doctype ∉ ("pandoc2html", "pandoc2pdf", "md2pdf", "minted2pdf")
 end
 
 function test_func(body)
@@ -24,7 +24,6 @@ using Dates
 Date(now())
 ```
 """
-
 for doctype in test_doctypes
     test_mock_weave(test_func, julia_markdown_body; informat = "markdown", doctype = doctype)
 end


### PR DESCRIPTION
Similar to #379  except it is now based on the new `master` branch.

A net reduction in lines of code while adding functionality. ;)

This PR also fixes an issue in the latex formats where unicode was not escaped in output chunks.
(Something similar should be done for `Pandoc` since it reports
```
julia> weave("FIR_design.jmd"; doctype="pandoc2pdf", cache=:refresh, keep_unicode=false)
[WARNING] Missing character: There is no π (U+03C0) in font [lmmono12-regular]:!
[WARNING] Missing character: There is no ⋮ (U+22EE) in font [lmmono12-regular]:!
[WARNING] Missing character: There is no ⋮ (U+22EE) in font [lmmono12-regular]:!
[ Info: Weaved to /home/jonas/.julia/dev/Weave/examples/FIR_design.pdf
"/home/jonas/.julia/dev/Weave/examples/FIR_design.pdf"
```