### PR TITLE
Fix for out_path only working for directories

### DIFF
--- a/src/Weave.jl
+++ b/src/Weave.jl
@@ -244,8 +244,16 @@ function specific_options!(weave_options, doctype)
 end
 
 get_out_path(doc, out_path, ext::Nothing = nothing) = get_out_path(doc, out_path, doc.format.extension)
-get_out_path(doc, out_path, ext) = abspath(get_cwd(doc, out_path), string(doc.basename , '.', ext))
-
+function get_out_path(doc, out_path, ext) 
+    if (out_path === :doc) || (out_path === :pwd)
+        abspath(get_cwd(doc, out_path), string(doc.basename, '.', ext))
+    elseif isempty(splitext(out_path)[2]) # directory given
+        abspath(get_cwd(doc, out_path), string(doc.basename, '.', ext))
+    else 
+        # out_path is given, but if extension is explitly provided override this will override the extension
+        abspath(string(splitext(out_path)[1], '.', ext))
+    end
+end
 """
     notebook(source::AbstractString; kwargs...)
 

--- a/test/run/test_module.jl
+++ b/test/run/test_module.jl
@@ -46,4 +46,14 @@ Core.eval(m, :(const a = $ary))
 Weave.clear_module!(m)
 @test_broken Base.summarysize(m) < size
 
+julia_markdown_body = """
+this is just to test the `out_path` option
+"""
+
+f_in = tempname()
+f_out = tempname() * ".md"
+write(f_in, julia_markdown_body)
+f = weave(f_in; out_path=f_out)
+@test isfile(f_out)
+
 end # @testset "clear_module!"


### PR DESCRIPTION
Now out_path creates the right file, see #383. All tests but 3 pass, but those were not working before on my system. All behavior should thus be the same.