### PR TITLE
Change tex escaping to tex comments

### DIFF
--- a/src/rendering/texformats.jl
+++ b/src/rendering/texformats.jl
@@ -152,11 +152,11 @@ end
 Base.@kwdef mutable struct LaTeXMinted <: LaTeXFormat
     description = "LaTeX using minted package for code highlighting"
     extension = "tex"
-    codestart = "\\begin{minted}[escapeinside=||, mathescape, fontsize=\\small, xleftmargin=0.5em]{julia}"
+    codestart = "\\begin{minted}[texcomments = true, mathescape, fontsize=\\small, xleftmargin=0.5em]{julia}"
     codeend = "\\end{minted}"
-    termstart = "\\begin{minted}[escapeinside=||, mathescape, fontsize=\\footnotesize, xleftmargin=0.5em]{jlcon}"
+    termstart = "\\begin{minted}[texcomments = true, mathescape, fontsize=\\footnotesize, xleftmargin=0.5em]{jlcon}"
     termend = "\\end{minted}"
-    outputstart = "\\begin{minted}[escapeinside=||, mathescape, fontsize=\\small, xleftmargin=0.5em, frame = leftline]{text}"
+    outputstart = "\\begin{minted}[texcomments = true, mathescape, fontsize=\\small, xleftmargin=0.5em, frame = leftline]{text}"
     outputend = "\\end{minted}"
     mimetypes = ["application/pdf", "image/png", "text/latex", "text/plain"]
     fig_ext = ".pdf"


### PR DESCRIPTION
Please see the [minted documentation](http://tug.ctan.org/tex-archive/macros/latex/contrib/minted/minted.pdf)  re. `escadeinside` (page 24):

> Escaping does not work inside strings and comments (for comments, there is texcomments).

If `escapeinside` doesn't work in strings or comments, then must it not be valid Julia code? It seems weird that one would expect a LaTeX block that they escaped to also execute as Julia. We can handle unicode input just fine without having to type \alpha. We can set `results = "tex"` and programmatically build LaTeX output.

I'd argue the most important use case for escaping LaTeX inside of Julia code is in the comments. Why not take an opinionated stance? I personally see this as quite useful.

Until then, I can't use the head revision of `Weave.jl` because the pipe operator is escaped. This fixes it for me, and I think makes the whole thing a bit cleaner :)