### PR TITLE
Add `render_chunk` and  `render_doc` methods

### DIFF
--- a/src/rendering/texformats.jl
+++ b/src/rendering/texformats.jl
@@ -173,6 +173,15 @@ Base.@kwdef mutable struct LaTeXMinted <: LaTeXFormat
     escape_closer = reverse(escape_starter)
 end
 register_format!("texminted", LaTeXMinted())
+    
+render_chunk(docformat::LaTeXMinted, chunk::DocChunk) = join((render_inline(c) for c in chunk.content))
+
+function render_doc(docformat::LaTeXMinted, body, doc)
+    return Mustache.render(
+        mt"{{{ :body }}}";
+        body = body
+    )
+end
 
 # Tex (directly to PDF)
 # ---------------------


### PR DESCRIPTION
Add `render_chunk` and  `render_doc` methods to `LaTeXMinted`

Suppose to correct the bug describes in [issue 389](https://github.com/JunoLab/Weave.jl/issues/389)