### PR TITLE
Force deletion of the temporary figure path to address Issue #440

### DIFF
--- a/src/run.jl
+++ b/src/run.jl
@@ -90,6 +90,8 @@ function run_doc(
         @info "Weaved all chunks" progress=1 _id=PROGRESS_ID
         cd_back()
         popdisplay(report) # ensure display pops out even if internal error occurs
+        # Temporary fig_path is not automatically removed because it contains files so...
+        startswith(fig_path, "jl_") && rm(normpath(cwd, fig_path), force=true, recursive=true)
     end
 
     return doc


### PR DESCRIPTION
The temporary fig_path is not being deleted when Julia exits because the path contains files.  This simply forces the removal of the directory and all contents whenever the fig_path starts with "jl_" as they are when created with mktempdir().  