### PR TITLE
Add optional softscoping

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 RelocatableFolders = "05181044-ff0b-4ac5-8273-598c1e38db00"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+SoftGlobalScope = "b85f4697-e234-5449-a836-ec8e2f98b302"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]

--- a/src/Weave.jl
+++ b/src/Weave.jl
@@ -1,6 +1,6 @@
 module Weave
 
-using Highlights, Mustache, Requires, Pkg, REPL, RelocatableFolders, Base64
+using Highlights, Mustache, Requires, Pkg, REPL, RelocatableFolders, Base64, SoftGlobalScope
 
 # directories
 const PKG_DIR = normpath(@__DIR__, "..")

--- a/src/config.jl
+++ b/src/config.jl
@@ -24,6 +24,7 @@ const _DEFAULT_PARAMS = Dict{Symbol,Any}(
     :fig_env => nothing,
     :out_width => nothing,
     :out_height => nothing,
+    :softscope => false,
 )
 const DEFAULT_PARAMS = deepcopy(_DEFAULT_PARAMS) # might be changed at runtime
 

--- a/src/reader/notebook.jl
+++ b/src/reader/notebook.jl
@@ -7,7 +7,7 @@ function parse_notebook(document_body)
     doc_no = 0
 
     # TODO: handle some of options ?
-    options = Dict{Symbol,Any}()
+    options = Dict{Symbol,Any}(:softscope => true)
     opt_string = ""
 
     chunks = map(nb["cells"]) do cell


### PR DESCRIPTION
Uses `SoftGlobalScope` to mimic IJulia behaviour for notebooks.
This eliminates the need of `global`  in loops at top level. 
Optionally, this could be enabled for .jmd files as well, allthough this is not enabled by default.

Closes #385 