### PR TITLE
Fixed figure numbering in inline code

### DIFF
--- a/src/display_methods.jl
+++ b/src/display_methods.jl
@@ -6,7 +6,7 @@ mutable struct Report <: AbstractDisplay
     basename::String
     format::WeaveFormat
     rich_output::String
-    fignum::Int
+    chunk_fignums::Dict{Int,Int}
     figures::Vector{String}
     cur_chunk::Union{Nothing,CodeChunk}
     mimetypes::Vector{String}
@@ -15,7 +15,7 @@ mutable struct Report <: AbstractDisplay
 end
 
 Report(cwd, basename, format, mimetypes) =
-    Report(cwd, basename, format, "", 1, String[], nothing, mimetypes, true, "")
+    Report(cwd, basename, format, "", Dict(0 => 1), String[], nothing, mimetypes, true, "")
 
 # Default mimetypes in order, can be overridden for some inside `run method` formats
 const default_mime_types = ["image/svg+xml", "image/png", "text/html", "text/plain"]
@@ -127,7 +127,11 @@ function add_figure(report::Report, data, m, ext)
         end
     end
 
-    push!(report.figures, rel_name)
-    report.fignum += 1
+    register_chunk_fig!(report, chunk, rel_name)
     return full_name
+end
+
+function register_chunk_fig!(report::Report, chunk::CodeChunk, rel_name::AbstractString)
+    push!(report.figures, rel_name)
+    report.chunk_fignums[chunk.number] = get(report.chunk_fignums, chunk.number, 0) + 1
 end

--- a/src/gadfly.jl
+++ b/src/gadfly.jl
@@ -28,8 +28,7 @@ function Base.display(report::Weave.Report, m::MIME"image/svg+xml", p::Gadfly.Pl
 
     full_name, rel_name = Weave.get_figname(report, chunk, ext = format)
 
-    push!(report.figures, rel_name)
-    report.fignum += 1
+    Weave.register_chunk_fig!(report, chunk, rel_name)
 
     if format == ".svg"
         Gadfly.draw(Gadfly.SVG(full_name, w, h), p)

--- a/src/plots.jl
+++ b/src/plots.jl
@@ -73,8 +73,7 @@ function add_plots_figure(report::Weave.Report, plot::Plots.Plot, ext)
     full_name, rel_name = Weave.get_figname(report, chunk, ext = ext)
 
     Plots.savefig(plot, full_name)
-    push!(report.figures, rel_name)
-    report.fignum += 1
+    Weave.register_chunk_fig!(report, chunk, rel_name)
     return full_name
 end
 

--- a/src/run.jl
+++ b/src/run.jl
@@ -255,7 +255,6 @@ function eval_chunk(doc::WeaveDoc, chunk::CodeChunk, report::Report, mod::Module
 
     execute_prehooks!(chunk)
 
-    report.fignum = 1
     report.cur_chunk = chunk
 
     if hasproperty(report.format, :out_width) && isnothing(chunk.options[:out_width])
@@ -325,7 +324,7 @@ end
 
 function get_figname(report::Report, chunk; fignum = nothing, ext = nothing)
     isnothing(ext) && (ext = chunk.options[:fig_ext])
-    isnothing(fignum) && (fignum = report.fignum)
+    isnothing(fignum) && (fignum = get(report.chunk_fignums, chunk.number, 1))
 
     chunkid = isnothing(chunk.options[:label]) ? chunk.number : chunk.options[:label]
     basename = string(report.basename, '_', chunkid, '_', fignum, ext)


### PR DESCRIPTION
Figure numbering restarted on every new inline code causing new figures to overwrite old ones.

Fixed by having `Report` store the current fig number of every chunk, not just the current chunk.